### PR TITLE
qr guia de remision

### DIFF
--- a/packages/report/src/Report/Render/QrRender.php
+++ b/packages/report/src/Report/Render/QrRender.php
@@ -46,25 +46,13 @@ class QrRender
     }
 
     /**
-     * @param Despatch $despatch
-     *
+     * Summary of getImageDespatch
+     * @param string $qr Link de la guía de remisión encontrada en el CDR
      * @return string
      */
-    public function getImageDespatch($despatch)
+    public function getImageDespatch(string $qr)
     {
-        $destinatario = $despatch->getDestinatario();
-        $params = [
-            $despatch->getCompany()->getRuc(),
-            $despatch->getTipoDoc(),
-            $despatch->getSerie(),
-            $despatch->getCorrelativo(),
-            $despatch->getFechaEmision()->format('Y-m-d'),
-            $destinatario->getTipoDoc(),
-            $destinatario->getNumDoc(),
-        ];
-        $content = implode('|', $params).'|';
-
-        return $this->getQrImage($content);
+        return $this->getQrImage($qr);
     }
 
     private function getQrImage(string $content)

--- a/packages/report/src/Report/Templates/despatch.html.twig
+++ b/packages/report/src/Report/Templates/despatch.html.twig
@@ -207,7 +207,7 @@
                         </blockquote>
                     </td>
                     <td width="15%" align="right">
-                        <img src="{{ qrCodeDespatch(doc)|image_b64('svg+xml') }}" alt="Qr Image">
+                        <img src="{{ qrCodeDespatch(params.system.qr)|image_b64('svg+xml') }}" alt="Qr Image">
                     </td>
                 </tr>
                 </tbody></table>


### PR DESCRIPTION
Agregar QR a la guia de remisión, el parametro a usar es el link que aparece en el CDR

$cdr = $result->getCdrResponse(); //obteniendo en CDR
$link = $cdr->getReference(); //Extraendo el LINK